### PR TITLE
Remove madvise stub from `glue.c`

### DIFF
--- a/glue.c
+++ b/glue.c
@@ -70,11 +70,6 @@ int epoll_wait(int epfd __unused, struct epoll_event *events __unused, int maxev
 	return 0;
 }
 
-int madvise(void *addr __unused, size_t length __unused, int advice __unused)
-{
-	return 0;
-}
-
 int mincore(void *addr __unused, size_t length __unused, unsigned char *vec __unused)
 {
 	return 0;


### PR DESCRIPTION
Recent unikraft version provides the symbol for the `madvise` syscall.
This commit removes the stub from the glue code, otherwise it will cause
a duplicate error during building.

Signed-off-by: Răzvan Vîrtan <virtanrazvan@gmail.com>