### PR TITLE
`Config.uk`: Imply `LIBUKMMAP` / `LIBPOSIX_MMAP`

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -6,8 +6,8 @@ menuconfig LIBGO
 	select LIBPOSIX_EVENT
 	select LIBUKSIGNAL
 	select PAGING
-	select LIBUKVMEM
-	select LIBPOSIX_MMAP
+	imply LIBUKVMEM
+	imply LIBPOSIX_MMAP
 	select LIBCOMPILER_RT
 	select LIBUNWIND
 	select LIBLWIP


### PR DESCRIPTION
Change `select LIBUKMMAP` to `imply LIBUKMMAP`. Do the same for `select LIBPOSIX_MMAP`. This is because eaxh may not be required for Go builds (and use the other one instead).

With `select` in place you cannot disable the selection, resulting in a dependency erorr when enabling the other one.

With `imply` as a soft select, any one can be disabled, removing the dependency error.